### PR TITLE
Update GitHub repository location

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Alfred.Mixfile do
   def project do
     [
       name: "Alfred",
-      source_url: "https://github.com/lee-dohm/alfred.ex",
+      source_url: "https://github.com/lee-dohm/alfred-ex",
       app: :alfred,
       version: @version,
       elixir: "~> 1.5",
@@ -54,7 +54,7 @@ defmodule Alfred.Mixfile do
       ],
       licenses: ["MIT"],
       maintainers: ["Lee Dohm"],
-      links: %{"GitHub" => "https://github.com/lee-dohm/alfred.ex"}
+      links: %{"GitHub" => "https://github.com/lee-dohm/alfred-ex"}
     ]
   end
 end


### PR DESCRIPTION
Change the GitHub repo location from lee-dohm/alfred.ex to lee-dohm/alfred-ex because the dot was interfering with some links in the documentation.